### PR TITLE
Improve map with stop markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ Basic bus tracker app that shows the path of common bus routes around MIT area.
 Simple bus tracker with Mapbox GL JS. The marker animates smoothly
 between stops and the route line is drawn on the map. Use the speed
 slider to control playback and the play/pause toggle during the animation.
-Bus stop data is loaded from the public MBTA API on page load.
+Bus stop data is loaded from the public MBTA API on page load. Each stop
+is now shown with a marker and popup containing the stop name. A new
+button lets you fetch the most recent bus position from the MBTA
+vehicles API.
 
 ### How to Run
 
 Clone this repository and run `index.html`. Before running, copy `config.sample.js`
 to `config.js` and replace the placeholder token with your own Mapbox token.
 The page will fetch live bus stop data from the MBTA API when the map loads.
+If no token is provided, a dialog will notify you that the map cannot load.
 
 ### Roadmap to Future Improvements
 This application will likely be restructured as a component for React App.

--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
     <button style="font-size: 1em" onclick="reset()">
         Reset Position
     </button>
+    <button style="font-size: 1em" onclick="updateLiveLocation()">
+        Live Position
+    </button>
     <label for="speed" style="margin-left:10px">Speed <span id="speed-value">0.01</span></label>
     <input id="speed" type="range" min="0.002" max="0.02" step="0.002" value="0.01">
 </div>


### PR DESCRIPTION
## Summary
- add mapbox token warning and default bus stop objects
- mark each bus stop with a popup and add flyTo animations
- expose button to fetch latest bus location
- update README with new instructions

## Testing
- `npm test` *(fails: Could not read package.json)*