### PR TITLE
Restore mapbox token

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ vehicles API.
 
 ### How to Run
 
-Clone this repository and run `index.html`. Before running, copy `config.sample.js`
-to `config.js` and replace the placeholder token with your own Mapbox token.
-The page will fetch live bus stop data from the MBTA API when the map loads.
-If no token is provided, a dialog will notify you that the map cannot load.
+Clone this repository and open `index.html` in your browser. For convenience the
+Mapbox access token is embedded directly in `mapanimation.js`, so no additional
+configuration is needed. The page will fetch live bus stop data from the MBTA
+API when the map loads.
 
 ### Roadmap to Future Improvements
 This application will likely be restructured as a component for React App.

--- a/index.html
+++ b/index.html
@@ -50,7 +50,6 @@
 </div>
 </body>
 </html>
-<script src="config.js"></script>
 <script src="mapanimation.js"></script>
 
 

--- a/mapanimation.js
+++ b/mapanimation.js
@@ -1,8 +1,4 @@
-mapboxgl.accessToken = typeof MAPBOX_TOKEN !== 'undefined' ? MAPBOX_TOKEN : '';
-if (!mapboxgl.accessToken) {
-    alert('Mapbox token missing. Please provide MAPBOX_TOKEN in config.js');
-}
-
+mapboxgl.accessToken = "pk.eyJ1IjoidmlrdG9ybTE4MSIsImEiOiJjbDBtdWI3b3IxYWNuM2xvYWJzNzQyeTkyIn0.eXFuDCWOigRsdOARXQZZ6w";
 //Generate the map
 let map = new mapboxgl.Map({
     container: 'map',


### PR DESCRIPTION
## Summary
- embed mapbox token directly into `mapanimation.js`
- drop `config.js` include in `index.html`
- update running instructions

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_685dcd90d8ac832e8cc29220e1c0cc03